### PR TITLE
Update flake.lock and nvfetcher sources

### DIFF
--- a/_sources/generated.json
+++ b/_sources/generated.json
@@ -1,7 +1,7 @@
 {
     "jovian-nixos": {
         "cargoLocks": null,
-        "date": "2023-04-25",
+        "date": "2023-06-30",
         "extract": null,
         "name": "jovian-nixos",
         "passthru": null,
@@ -13,11 +13,11 @@
             "name": null,
             "owner": "Jovian-Experiments",
             "repo": "Jovian-NixOS",
-            "rev": "4fe665707364b3c4228f66895f1b6316634ceabc",
-            "sha256": "sha256-k1DlJCHQgEix/Be8m4MZlNYWocv7NxlPiLcPTXgcs+w=",
+            "rev": "449faaa41e55c504d2068f2a77c91a0dbc5b191d",
+            "sha256": "sha256-E4Lk1HlRSvbcflAB23U1Arul013IN34kvReQyulzFTw=",
             "type": "github"
         },
-        "version": "4fe665707364b3c4228f66895f1b6316634ceabc"
+        "version": "449faaa41e55c504d2068f2a77c91a0dbc5b191d"
     },
     "proton-ge-custom": {
         "cargoLocks": null,
@@ -28,11 +28,11 @@
         "pinned": false,
         "src": {
             "name": null,
-            "sha256": "sha256-/70DtApcja+6U+Rb1lUcEyUSrW/LqRIOJfDVENDNBIU=",
+            "sha256": "sha256-OPwmVxBGaWo51pDJcqvxvZ8qxMH8X0DwZTpwiKbdx/I=",
             "type": "url",
-            "url": "https://github.com/GloriousEggroll/proton-ge-custom/releases/download/GE-Proton7-55/GE-Proton7-55.tar.gz"
+            "url": "https://github.com/GloriousEggroll/proton-ge-custom/releases/download/GE-Proton8-4/GE-Proton8-4.tar.gz"
         },
-        "version": "GE-Proton7-55"
+        "version": "GE-Proton8-4"
     },
     "rime-pinyin-zhwiki": {
         "cargoLocks": null,
@@ -43,15 +43,15 @@
         "pinned": false,
         "src": {
             "name": null,
-            "sha256": "sha256-0B02FGISHqvrBUGkERdplhrx8zo6SV9hG2qRbSUqqd0=",
+            "sha256": "sha256-SB2TcvJb/7D3cO3NG34QecMxWMAFwwHCSr3sKHLZa3o=",
             "type": "url",
-            "url": "https://github.com/felixonmars/fcitx5-pinyin-zhwiki/releases/download/0.2.4/zhwiki-20230329.dict.yaml"
+            "url": "https://github.com/felixonmars/fcitx5-pinyin-zhwiki/releases/download/0.2.4/zhwiki-20230605.dict.yaml"
         },
-        "version": "20230329"
+        "version": "20230605"
     },
     "yacd-meta": {
         "cargoLocks": null,
-        "date": "2023-04-25",
+        "date": "2023-06-29",
         "extract": null,
         "name": "yacd-meta",
         "passthru": null,
@@ -63,10 +63,10 @@
             "name": null,
             "owner": "MetaCubeX",
             "repo": "Yacd-meta",
-            "rev": "1d93beb543ad2e1216e5c480d4ea04c1bb45efaf",
-            "sha256": "sha256-9Zt1CkhdC5m2FTtVr1EtnyFh2+Gi13xksT1BSzdEU2E=",
+            "rev": "2d0c52cecf9ee7ed8446d2fa240291ef83facbde",
+            "sha256": "sha256-Pi1LV+DnBiFqcelPz/F6Ip2wH+GC87vE+9H4nCaWlBU=",
             "type": "github"
         },
-        "version": "1d93beb543ad2e1216e5c480d4ea04c1bb45efaf"
+        "version": "2d0c52cecf9ee7ed8446d2fa240291ef83facbde"
     }
 }

--- a/_sources/generated.nix
+++ b/_sources/generated.nix
@@ -3,42 +3,42 @@
 {
   jovian-nixos = {
     pname = "jovian-nixos";
-    version = "4fe665707364b3c4228f66895f1b6316634ceabc";
-    src = fetchFromGitHub ({
+    version = "449faaa41e55c504d2068f2a77c91a0dbc5b191d";
+    src = fetchFromGitHub {
       owner = "Jovian-Experiments";
       repo = "Jovian-NixOS";
-      rev = "4fe665707364b3c4228f66895f1b6316634ceabc";
+      rev = "449faaa41e55c504d2068f2a77c91a0dbc5b191d";
       fetchSubmodules = false;
-      sha256 = "sha256-k1DlJCHQgEix/Be8m4MZlNYWocv7NxlPiLcPTXgcs+w=";
-    });
-    date = "2023-04-25";
+      sha256 = "sha256-E4Lk1HlRSvbcflAB23U1Arul013IN34kvReQyulzFTw=";
+    };
+    date = "2023-06-30";
   };
   proton-ge-custom = {
     pname = "proton-ge-custom";
-    version = "GE-Proton7-55";
+    version = "GE-Proton8-4";
     src = fetchurl {
-      url = "https://github.com/GloriousEggroll/proton-ge-custom/releases/download/GE-Proton7-55/GE-Proton7-55.tar.gz";
-      sha256 = "sha256-/70DtApcja+6U+Rb1lUcEyUSrW/LqRIOJfDVENDNBIU=";
+      url = "https://github.com/GloriousEggroll/proton-ge-custom/releases/download/GE-Proton8-4/GE-Proton8-4.tar.gz";
+      sha256 = "sha256-OPwmVxBGaWo51pDJcqvxvZ8qxMH8X0DwZTpwiKbdx/I=";
     };
   };
   rime-pinyin-zhwiki = {
     pname = "rime-pinyin-zhwiki";
-    version = "20230329";
+    version = "20230605";
     src = fetchurl {
-      url = "https://github.com/felixonmars/fcitx5-pinyin-zhwiki/releases/download/0.2.4/zhwiki-20230329.dict.yaml";
-      sha256 = "sha256-0B02FGISHqvrBUGkERdplhrx8zo6SV9hG2qRbSUqqd0=";
+      url = "https://github.com/felixonmars/fcitx5-pinyin-zhwiki/releases/download/0.2.4/zhwiki-20230605.dict.yaml";
+      sha256 = "sha256-SB2TcvJb/7D3cO3NG34QecMxWMAFwwHCSr3sKHLZa3o=";
     };
   };
   yacd-meta = {
     pname = "yacd-meta";
-    version = "1d93beb543ad2e1216e5c480d4ea04c1bb45efaf";
-    src = fetchFromGitHub ({
+    version = "2d0c52cecf9ee7ed8446d2fa240291ef83facbde";
+    src = fetchFromGitHub {
       owner = "MetaCubeX";
       repo = "Yacd-meta";
-      rev = "1d93beb543ad2e1216e5c480d4ea04c1bb45efaf";
+      rev = "2d0c52cecf9ee7ed8446d2fa240291ef83facbde";
       fetchSubmodules = false;
-      sha256 = "sha256-9Zt1CkhdC5m2FTtVr1EtnyFh2+Gi13xksT1BSzdEU2E=";
-    });
-    date = "2023-04-25";
+      sha256 = "sha256-Pi1LV+DnBiFqcelPz/F6Ip2wH+GC87vE+9H4nCaWlBU=";
+    };
+    date = "2023-06-29";
   };
 }

--- a/flake.lock
+++ b/flake.lock
@@ -76,11 +76,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1686186025,
-        "narHash": "sha256-SuQjKsO1G87qM5j8VNtq6kIw4ILYE03Y8yL/FoKwR+4=",
+        "lastModified": 1688082682,
+        "narHash": "sha256-nMG/A7qYm9pyHJowKuaNmNYgo748xZrzMJPqtoGozSA=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "057d95721ee67d421391dda7031977d247ddec28",
+        "rev": "4d350bb94fdf8ec9d2e22d68bb13e136d73aa9d8",
         "type": "github"
       },
       "original": {
@@ -96,11 +96,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1686222354,
-        "narHash": "sha256-dtqnAwzucKZv54dTrLetIXhOavUrCsdqOe+JtFH9riE=",
+        "lastModified": 1687968164,
+        "narHash": "sha256-L9jr2zCB6NIaBE3towusjGBigsnE2pMID8wBGkYbTS4=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "5d9f362aecd7a4c2e8a3bf2afddb49051988cab9",
+        "rev": "8002e7cb899bc2a02a2ebfb7f999fcd7c18b92a1",
         "type": "github"
       },
       "original": {
@@ -120,11 +120,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1686384854,
-        "narHash": "sha256-Jkuxzrc/ab2Zi1onSdGUVe3aY5NJPCdPIaPfpCX4EXU=",
+        "lastModified": 1688237303,
+        "narHash": "sha256-+mm3PAt+VWhX+0bn3l5dqOR2TfIdmuzTHuPLI5GyHfY=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "54cb49d301ec3211e22b3e75d2aa4be346d0c1a2",
+        "rev": "54c0d37eb161dd90a6da788676143091e5108613",
         "type": "github"
       },
       "original": {
@@ -191,11 +191,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1685662779,
-        "narHash": "sha256-cKDDciXGpMEjP1n6HlzKinN0H+oLmNpgeCTzYnsA2po=",
+        "lastModified": 1687762428,
+        "narHash": "sha256-DIf7mi45PKo+s8dOYF+UlXHzE0Wl/+k3tXUyAoAnoGE=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "71fb97f0d875fd4de4994dfb849f2c75e17eb6c3",
+        "rev": "37dd7bb15791c86d55c5121740a1887ab55ee836",
         "type": "github"
       },
       "original": {
@@ -209,11 +209,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1685518550,
-        "narHash": "sha256-o2d0KcvaXzTrPRIo0kOLV0/QXHhDQ5DTi+OxcjO8xqY=",
+        "lastModified": 1687709756,
+        "narHash": "sha256-Y5wKlQSkgEK2weWdOu4J3riRd+kV/VCgHsqLNTTWQ/0=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "a1720a10a6cfe8234c0e93907ffe81be440f4cef",
+        "rev": "dbabf0ca0c0c4bce6ea5eaf65af5cb694d2082c7",
         "type": "github"
       },
       "original": {
@@ -229,11 +229,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1686391840,
-        "narHash": "sha256-5S0APl6Mfm6a37taHwvuf11UHnAX0+PnoWQbsYbMUnc=",
+        "lastModified": 1688220547,
+        "narHash": "sha256-cNKKLPaEOxd6t22Mt3tHGubyylbKGdoi2A3QkMTKes0=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "0144ac418ef633bfc9dbd89b8c199ad3a617c59f",
+        "rev": "89d10f8adce369a80e046c2fd56d1e7b7507bb5b",
         "type": "github"
       },
       "original": {
@@ -250,11 +250,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1686414173,
-        "narHash": "sha256-UksReMzPwEuU+nqZBRWrPkpnE/JK3a1PIvKofdOeUUw=",
+        "lastModified": 1688255021,
+        "narHash": "sha256-BPsKHa/7VY8iUL3QmNSH14qlnLrxp63E3N9o4JMaS90=",
         "owner": "nix-community",
         "repo": "nixd",
-        "rev": "f67e677c9ec344d0af43e168edeea12f110cf626",
+        "rev": "84f86fec537f31d53fea2c74a408fb596ddbfd90",
         "type": "github"
       },
       "original": {
@@ -265,11 +265,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1686396027,
-        "narHash": "sha256-gE+csxJoXuNn5ZnlgNj0GnMQ2y4heBtDqkB1af8vfjU=",
+        "lastModified": 1686838567,
+        "narHash": "sha256-aqKCUD126dRlVSKV6vWuDCitfjFrZlkwNuvj5LtjRRU=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "70d5f55faee9c1e141e32e6be1e77d13e5a570db",
+        "rev": "429f232fe1dc398c5afea19a51aad6931ee0fb89",
         "type": "github"
       },
       "original": {
@@ -281,11 +281,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1686319658,
-        "narHash": "sha256-tGWdoUAqKnE866mYFlEfc2a99kxFy31hOQJH5YQKrTQ=",
+        "lastModified": 1688049487,
+        "narHash": "sha256-100g4iaKC9MalDjUW9iN6Jl/OocTDtXdeAj7pEGIRh4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "ae766d59b07c450e0f1de8a1bfd6529089f40849",
+        "rev": "4bc72cae107788bf3f24f30db2e2f685c9298dc9",
         "type": "github"
       },
       "original": {
@@ -331,11 +331,11 @@
     },
     "nixpkgs-stable_2": {
       "locked": {
-        "lastModified": 1686237827,
-        "narHash": "sha256-fAZB+Zkcmc+qlauiFnIH9+2qgwM0NO/ru5pWEw3tDow=",
+        "lastModified": 1688109178,
+        "narHash": "sha256-BSdeYp331G4b1yc7GIRgAnfUyaktW2nl7k0C577Tttk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "81ed90058a851eb73be835c770e062c6938c8a9e",
+        "rev": "b72aa95f7f096382bff3aea5f8fde645bca07422",
         "type": "github"
       },
       "original": {
@@ -347,27 +347,27 @@
     },
     "nixpkgs-stable_3": {
       "locked": {
-        "lastModified": 1685758009,
-        "narHash": "sha256-IT4Z5WGhafrq+xbDTyuKrRPRQ1f+kVOtE+4JU1CHFeo=",
+        "lastModified": 1687031877,
+        "narHash": "sha256-yMFcVeI+kZ6KD2QBrFPNsvBrLq2Gt//D0baHByMrjFY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "eaf03591711b46d21abc7082a8ebee4681f9dbeb",
+        "rev": "e2e2059d19668dab1744301b8b0e821e3aae9c99",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "release-22.11",
+        "ref": "release-23.05",
         "repo": "nixpkgs",
         "type": "github"
       }
     },
     "nur": {
       "locked": {
-        "lastModified": 1686408315,
-        "narHash": "sha256-WoG7NH9ZlpmyvVKY8U2IsRtJV5bVyeuxq70FPep8UvA=",
+        "lastModified": 1688255096,
+        "narHash": "sha256-63yMmlSWLww3QUHRaTuIfBtBhG88nrQKtglvE0eBBWM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f98c2f1c540867470df7c084351de02d62f8d208",
+        "rev": "1da3b1e1af054b664eb6dfa5b7c41c262176584c",
         "type": "github"
       },
       "original": {
@@ -391,11 +391,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1686399233,
-        "narHash": "sha256-vaSR/RFDhGAmCqSg++TYMnp7cWh/uUEsrf3+zDqZKcw=",
+        "lastModified": 1688191889,
+        "narHash": "sha256-EZKaOTXYj7spUq2UwW6RMH6F4f0mY7cxPQknsGpU+rA=",
         "owner": "linyinfeng",
         "repo": "oranc",
-        "rev": "a7abb49e6c6b00be7e55b05c05582fb87b14133f",
+        "rev": "db860695ddcefc2090d1603fa9b347aef2adf04f",
         "type": "github"
       },
       "original": {
@@ -459,11 +459,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1686364106,
-        "narHash": "sha256-h4gCQg+jizmAbdg6UPlhxQVk4A7Ar/zoLa0wx3wBya0=",
+        "lastModified": 1688178944,
+        "narHash": "sha256-4fef6jlv73WW6FLXssEa88WaTVEU268ipI6fatg9vRE=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "ba011dd1c5028dbb880bc3b0f427e0ff689e6203",
+        "rev": "ef95001485c25edb43ea236bdb03640b9073abef",
         "type": "github"
       },
       "original": {
@@ -480,11 +480,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1685848844,
-        "narHash": "sha256-Iury+/SVbAwLES76QJSiKFiQDzmf/8Hsq8j54WF2qyw=",
+        "lastModified": 1687398569,
+        "narHash": "sha256-e/umuIKFcFtZtWeX369Hbdt9r+GQ48moDmlTcyHWL28=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "a522e12ee35e50fa7d902a164a9796e420e6e75b",
+        "rev": "2ff6973350682f8d16371f8c071a304b8067f192",
         "type": "github"
       },
       "original": {
@@ -516,11 +516,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1685519364,
-        "narHash": "sha256-rE9c9jWDSc5Nj0OjNzBENaJ6j4YBphcqSPia2IwCMLA=",
+        "lastModified": 1688026376,
+        "narHash": "sha256-qJmkr9BWDpqblk4E9/rCsAEl39y2n4Ycw6KRopvpUcY=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "6521a278bcba66b440554cc1350403594367b4ac",
+        "rev": "df3f32b0cc253dfc7009b7317e8f0e7ccd70b1cf",
         "type": "github"
       },
       "original": {
@@ -536,11 +536,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1685519364,
-        "narHash": "sha256-rE9c9jWDSc5Nj0OjNzBENaJ6j4YBphcqSPia2IwCMLA=",
+        "lastModified": 1688026376,
+        "narHash": "sha256-qJmkr9BWDpqblk4E9/rCsAEl39y2n4Ycw6KRopvpUcY=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "6521a278bcba66b440554cc1350403594367b4ac",
+        "rev": "df3f32b0cc253dfc7009b7317e8f0e7ccd70b1cf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<pre># Update report
# flake lock update
[K[Kwarning: updating lock file '/home/runner/work/nixos/nixos/flake.lock':
• Updated input 'disko':
    'github:nix-community/disko/5d9f362aecd7a4c2e8a3bf2afddb49051988cab9' (2023-06-08)
  → 'github:nix-community/disko/8002e7cb899bc2a02a2ebfb7f999fcd7c18b92a1' (2023-06-28)
• Updated input 'emacs-overlay':
    'github:nix-community/emacs-overlay/54cb49d301ec3211e22b3e75d2aa4be346d0c1a2' (2023-06-10)
  → 'github:nix-community/emacs-overlay/54c0d37eb161dd90a6da788676143091e5108613' (2023-07-01)
• Updated input 'emacs-overlay/nixpkgs-stable':
    'github:NixOS/nixpkgs/81ed90058a851eb73be835c770e062c6938c8a9e' (2023-06-08)
  → 'github:NixOS/nixpkgs/b72aa95f7f096382bff3aea5f8fde645bca07422' (2023-06-30)
• Updated input 'flake-utils':
    'github:numtide/flake-utils/a1720a10a6cfe8234c0e93907ffe81be440f4cef' (2023-05-31)
  → 'github:numtide/flake-utils/dbabf0ca0c0c4bce6ea5eaf65af5cb694d2082c7' (2023-06-25)
• Updated input 'home-manager':
    'github:nix-community/home-manager/0144ac418ef633bfc9dbd89b8c199ad3a617c59f' (2023-06-10)
  → 'github:nix-community/home-manager/89d10f8adce369a80e046c2fd56d1e7b7507bb5b' (2023-07-01)
• Updated input 'nixd':
    'github:nix-community/nixd/f67e677c9ec344d0af43e168edeea12f110cf626' (2023-06-10)
  → 'github:nix-community/nixd/84f86fec537f31d53fea2c74a408fb596ddbfd90' (2023-07-01)
• Updated input 'nixos-hardware':
    'github:NixOS/nixos-hardware/70d5f55faee9c1e141e32e6be1e77d13e5a570db' (2023-06-10)
  → 'github:NixOS/nixos-hardware/429f232fe1dc398c5afea19a51aad6931ee0fb89' (2023-06-15)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/ae766d59b07c450e0f1de8a1bfd6529089f40849' (2023-06-09)
  → 'github:nixos/nixpkgs/4bc72cae107788bf3f24f30db2e2f685c9298dc9' (2023-06-29)
• Updated input 'nur':
    'github:nix-community/NUR/f98c2f1c540867470df7c084351de02d62f8d208' (2023-06-10)
  → 'github:nix-community/NUR/1da3b1e1af054b664eb6dfa5b7c41c262176584c' (2023-07-01)
• Updated input 'oranc':
    'github:linyinfeng/oranc/a7abb49e6c6b00be7e55b05c05582fb87b14133f' (2023-06-10)
  → 'github:linyinfeng/oranc/db860695ddcefc2090d1603fa9b347aef2adf04f' (2023-07-01)
• Updated input 'oranc/crane':
    'github:ipetkov/crane/057d95721ee67d421391dda7031977d247ddec28' (2023-06-08)
  → 'github:ipetkov/crane/4d350bb94fdf8ec9d2e22d68bb13e136d73aa9d8' (2023-06-29)
• Updated input 'oranc/flake-parts':
    'github:hercules-ci/flake-parts/71fb97f0d875fd4de4994dfb849f2c75e17eb6c3' (2023-06-01)
  → 'github:hercules-ci/flake-parts/37dd7bb15791c86d55c5121740a1887ab55ee836' (2023-06-26)
• Updated input 'oranc/rust-overlay':
    'github:oxalica/rust-overlay/ba011dd1c5028dbb880bc3b0f427e0ff689e6203' (2023-06-10)
  → 'github:oxalica/rust-overlay/ef95001485c25edb43ea236bdb03640b9073abef' (2023-07-01)
• Updated input 'oranc/treefmt-nix':
    'github:numtide/treefmt-nix/6521a278bcba66b440554cc1350403594367b4ac' (2023-05-31)
  → 'github:numtide/treefmt-nix/df3f32b0cc253dfc7009b7317e8f0e7ccd70b1cf' (2023-06-29)
• Updated input 'sops-nix':
    'github:Mic92/sops-nix/a522e12ee35e50fa7d902a164a9796e420e6e75b' (2023-06-04)
  → 'github:Mic92/sops-nix/2ff6973350682f8d16371f8c071a304b8067f192' (2023-06-22)
• Updated input 'sops-nix/nixpkgs-stable':
    'github:NixOS/nixpkgs/eaf03591711b46d21abc7082a8ebee4681f9dbeb' (2023-06-03)
  → 'github:NixOS/nixpkgs/e2e2059d19668dab1744301b8b0e821e3aae9c99' (2023-06-17)
• Updated input 'treefmt-nix':
    'github:numtide/treefmt-nix/6521a278bcba66b440554cc1350403594367b4ac' (2023-05-31)
  → 'github:numtide/treefmt-nix/df3f32b0cc253dfc7009b7317e8f0e7ccd70b1cf' (2023-06-29)
warning: Git tree '/home/runner/work/nixos/nixos' is dirty

# nvfetcher update
# CheckArchLinux: rime-pinyin-zhwiki
  NvcheckerOptions
    stripPrefix: 0.2.4.
# CheckGitHubRelease
    owner: GloriousEggroll
    repo: proton-ge-custom
# FetchUrl
  url: https://github.com/GloriousEggroll/proton-ge-custom/releases/download/GE-Proton8-4/GE-Proton8-4.tar.gz
# CheckGit
    url: https://github.com/Jovian-Experiments/Jovian-NixOS
    branch: 
# FetchGitHub
  owner: Jovian-Experiments
  repo: Jovian-NixOS
  rev: 449faaa41e55c504d2068f2a77c91a0dbc5b191d
  deepClone: False
  fetchSubmodules: False
  leaveDotGit: False
# GetGitCommitDate
  url: https://github.com/Jovian-Experiments/Jovian-NixOS
  rev: 449faaa41e55c504d2068f2a77c91a0dbc5b191d
  format: 
# FetchUrl
  url: https://github.com/felixonmars/fcitx5-pinyin-zhwiki/releases/download/0.2.4/zhwiki-20230605.dict.yaml
# CheckGit
    url: https://github.com/MetaCubeX/Yacd-meta
    branch: gh-pages
# FetchGitHub
  owner: MetaCubeX
  repo: Yacd-meta
  rev: 2d0c52cecf9ee7ed8446d2fa240291ef83facbde
  deepClone: False
  fetchSubmodules: False
  leaveDotGit: False
# GetGitCommitDate
  url: https://github.com/MetaCubeX/Yacd-meta
  rev: 2d0c52cecf9ee7ed8446d2fa240291ef83facbde
  format: 
Changes:
jovian-nixos: 4fe665707364b3c4228f66895f1b6316634ceabc → 449faaa41e55c504d2068f2a77c91a0dbc5b191d
rime-pinyin-zhwiki: 20230329 → 20230605
yacd-meta: 1d93beb543ad2e1216e5c480d4ea04c1bb45efaf → 2d0c52cecf9ee7ed8446d2fa240291ef83facbde
proton-ge-custom: GE-Proton7-55 → GE-Proton8-4


</pre>