### PR TITLE
Update flake.lock and nvfetcher sources

### DIFF
--- a/_sources/generated.json
+++ b/_sources/generated.json
@@ -1,7 +1,7 @@
 {
     "cape-yasnippet": {
         "cargoLocks": null,
-        "date": "2023-05-19",
+        "date": "2023-07-12",
         "extract": null,
         "name": "cape-yasnippet",
         "passthru": null,
@@ -13,15 +13,15 @@
             "name": null,
             "owner": "elken",
             "repo": "cape-yasnippet",
-            "rev": "ad8c27c2f748b410e7dd568927e99081f87b98b9",
-            "sha256": "sha256-JmJljrvo9AcEVALv5GHa/XdpVLAUaww3wGmlXSAoITs=",
+            "rev": "ed06497466718fc6de43606cbc3a6ac9f237008a",
+            "sha256": "sha256-bG6rS9yI3WOqcGu1aOH98hlzY6Uac6ZcpvHYENFjrps=",
             "type": "github"
         },
-        "version": "ad8c27c2f748b410e7dd568927e99081f87b98b9"
+        "version": "ed06497466718fc6de43606cbc3a6ac9f237008a"
     },
     "jovian-nixos": {
         "cargoLocks": null,
-        "date": "2023-06-30",
+        "date": "2023-07-30",
         "extract": null,
         "name": "jovian-nixos",
         "passthru": null,
@@ -33,11 +33,11 @@
             "name": null,
             "owner": "Jovian-Experiments",
             "repo": "Jovian-NixOS",
-            "rev": "449faaa41e55c504d2068f2a77c91a0dbc5b191d",
-            "sha256": "sha256-E4Lk1HlRSvbcflAB23U1Arul013IN34kvReQyulzFTw=",
+            "rev": "9758792434ae5693cb6c70454f534a47b4fe5241",
+            "sha256": "sha256-Vt4gtWbdeuPGAm4O+tW1opHZcc4xNokMvWn35OotHvc=",
             "type": "github"
         },
-        "version": "449faaa41e55c504d2068f2a77c91a0dbc5b191d"
+        "version": "9758792434ae5693cb6c70454f534a47b4fe5241"
     },
     "proton-ge-custom": {
         "cargoLocks": null,
@@ -48,11 +48,11 @@
         "pinned": false,
         "src": {
             "name": null,
-            "sha256": "sha256-OPwmVxBGaWo51pDJcqvxvZ8qxMH8X0DwZTpwiKbdx/I=",
+            "sha256": "sha256-yZn4vrG9FCX2Wvpz3aKPaqBK4ttNupZmrmX13QBDZFo=",
             "type": "url",
-            "url": "https://github.com/GloriousEggroll/proton-ge-custom/releases/download/GE-Proton8-4/GE-Proton8-4.tar.gz"
+            "url": "https://github.com/GloriousEggroll/proton-ge-custom/releases/download/GE-Proton8-9/GE-Proton8-9.tar.gz"
         },
-        "version": "GE-Proton8-4"
+        "version": "GE-Proton8-9"
     },
     "rime-pinyin-zhwiki": {
         "cargoLocks": null,
@@ -63,15 +63,15 @@
         "pinned": false,
         "src": {
             "name": null,
-            "sha256": "sha256-SB2TcvJb/7D3cO3NG34QecMxWMAFwwHCSr3sKHLZa3o=",
+            "sha256": "sha256-KMlsC+04NjXSsIDskVVY69MKta4W22EDcKUVRtM0diA=",
             "type": "url",
-            "url": "https://github.com/felixonmars/fcitx5-pinyin-zhwiki/releases/download/0.2.4/zhwiki-20230605.dict.yaml"
+            "url": "https://github.com/felixonmars/fcitx5-pinyin-zhwiki/releases/download/0.2.4/zhwiki-20230728.dict.yaml"
         },
-        "version": "20230605"
+        "version": "20230728"
     },
     "yacd-meta": {
         "cargoLocks": null,
-        "date": "2023-06-29",
+        "date": "2023-07-15",
         "extract": null,
         "name": "yacd-meta",
         "passthru": null,
@@ -83,10 +83,10 @@
             "name": null,
             "owner": "MetaCubeX",
             "repo": "Yacd-meta",
-            "rev": "2d0c52cecf9ee7ed8446d2fa240291ef83facbde",
-            "sha256": "sha256-Pi1LV+DnBiFqcelPz/F6Ip2wH+GC87vE+9H4nCaWlBU=",
+            "rev": "fa8f6c1a27b37c17cd89b9255a584d21f6ddb7bd",
+            "sha256": "sha256-SpyDC+cgnKk27LgS6VS7hxpx40V2U97CqYgIsEbwDsg=",
             "type": "github"
         },
-        "version": "2d0c52cecf9ee7ed8446d2fa240291ef83facbde"
+        "version": "fa8f6c1a27b37c17cd89b9255a584d21f6ddb7bd"
     }
 }

--- a/_sources/generated.nix
+++ b/_sources/generated.nix
@@ -3,54 +3,54 @@
 {
   cape-yasnippet = {
     pname = "cape-yasnippet";
-    version = "ad8c27c2f748b410e7dd568927e99081f87b98b9";
+    version = "ed06497466718fc6de43606cbc3a6ac9f237008a";
     src = fetchFromGitHub {
       owner = "elken";
       repo = "cape-yasnippet";
-      rev = "ad8c27c2f748b410e7dd568927e99081f87b98b9";
+      rev = "ed06497466718fc6de43606cbc3a6ac9f237008a";
       fetchSubmodules = false;
-      sha256 = "sha256-JmJljrvo9AcEVALv5GHa/XdpVLAUaww3wGmlXSAoITs=";
+      sha256 = "sha256-bG6rS9yI3WOqcGu1aOH98hlzY6Uac6ZcpvHYENFjrps=";
     };
-    date = "2023-05-19";
+    date = "2023-07-12";
   };
   jovian-nixos = {
     pname = "jovian-nixos";
-    version = "449faaa41e55c504d2068f2a77c91a0dbc5b191d";
+    version = "9758792434ae5693cb6c70454f534a47b4fe5241";
     src = fetchFromGitHub {
       owner = "Jovian-Experiments";
       repo = "Jovian-NixOS";
-      rev = "449faaa41e55c504d2068f2a77c91a0dbc5b191d";
+      rev = "9758792434ae5693cb6c70454f534a47b4fe5241";
       fetchSubmodules = false;
-      sha256 = "sha256-E4Lk1HlRSvbcflAB23U1Arul013IN34kvReQyulzFTw=";
+      sha256 = "sha256-Vt4gtWbdeuPGAm4O+tW1opHZcc4xNokMvWn35OotHvc=";
     };
-    date = "2023-06-30";
+    date = "2023-07-30";
   };
   proton-ge-custom = {
     pname = "proton-ge-custom";
-    version = "GE-Proton8-4";
+    version = "GE-Proton8-9";
     src = fetchurl {
-      url = "https://github.com/GloriousEggroll/proton-ge-custom/releases/download/GE-Proton8-4/GE-Proton8-4.tar.gz";
-      sha256 = "sha256-OPwmVxBGaWo51pDJcqvxvZ8qxMH8X0DwZTpwiKbdx/I=";
+      url = "https://github.com/GloriousEggroll/proton-ge-custom/releases/download/GE-Proton8-9/GE-Proton8-9.tar.gz";
+      sha256 = "sha256-yZn4vrG9FCX2Wvpz3aKPaqBK4ttNupZmrmX13QBDZFo=";
     };
   };
   rime-pinyin-zhwiki = {
     pname = "rime-pinyin-zhwiki";
-    version = "20230605";
+    version = "20230728";
     src = fetchurl {
-      url = "https://github.com/felixonmars/fcitx5-pinyin-zhwiki/releases/download/0.2.4/zhwiki-20230605.dict.yaml";
-      sha256 = "sha256-SB2TcvJb/7D3cO3NG34QecMxWMAFwwHCSr3sKHLZa3o=";
+      url = "https://github.com/felixonmars/fcitx5-pinyin-zhwiki/releases/download/0.2.4/zhwiki-20230728.dict.yaml";
+      sha256 = "sha256-KMlsC+04NjXSsIDskVVY69MKta4W22EDcKUVRtM0diA=";
     };
   };
   yacd-meta = {
     pname = "yacd-meta";
-    version = "2d0c52cecf9ee7ed8446d2fa240291ef83facbde";
+    version = "fa8f6c1a27b37c17cd89b9255a584d21f6ddb7bd";
     src = fetchFromGitHub {
       owner = "MetaCubeX";
       repo = "Yacd-meta";
-      rev = "2d0c52cecf9ee7ed8446d2fa240291ef83facbde";
+      rev = "fa8f6c1a27b37c17cd89b9255a584d21f6ddb7bd";
       fetchSubmodules = false;
-      sha256 = "sha256-Pi1LV+DnBiFqcelPz/F6Ip2wH+GC87vE+9H4nCaWlBU=";
+      sha256 = "sha256-SpyDC+cgnKk27LgS6VS7hxpx40V2U97CqYgIsEbwDsg=";
     };
-    date = "2023-06-29";
+    date = "2023-07-15";
   };
 }

--- a/flake.lock
+++ b/flake.lock
@@ -13,11 +13,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1686620679,
-        "narHash": "sha256-Ck/r3f+W9mOn3cHn5ii/fogBiJtosFnDaOQveaJ0zVU=",
+        "lastModified": 1689457600,
+        "narHash": "sha256-1XLn2ZZMaqQx+Ys3eel5hQRkgUn3DeHcVb2JT8WYU0A=",
         "owner": "zhaofengli",
         "repo": "attic",
-        "rev": "4fedffe6a1020edfcfa7bef18d21321d4983b3a7",
+        "rev": "4902d57f5dae8ec660ee9ee14c45c2192f9fe8b1",
         "type": "github"
       },
       "original": {
@@ -63,11 +63,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1687968164,
-        "narHash": "sha256-L9jr2zCB6NIaBE3towusjGBigsnE2pMID8wBGkYbTS4=",
+        "lastModified": 1690739034,
+        "narHash": "sha256-roW02IaiQ3gnEEDMCDWL5YyN+C4nBf/te6vfL7rG0jk=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "8002e7cb899bc2a02a2ebfb7f999fcd7c18b92a1",
+        "rev": "4015740375676402a2ee6adebc3c30ea625b9a94",
         "type": "github"
       },
       "original": {
@@ -115,11 +115,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1687709756,
-        "narHash": "sha256-Y5wKlQSkgEK2weWdOu4J3riRd+kV/VCgHsqLNTTWQ/0=",
+        "lastModified": 1689068808,
+        "narHash": "sha256-6ixXo3wt24N/melDWjq70UuHQLxGV8jZvooRanIHXw0=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "dbabf0ca0c0c4bce6ea5eaf65af5cb694d2082c7",
+        "rev": "919d646de7be200f3bf08cb76ae1f09402b6f9b4",
         "type": "github"
       },
       "original": {
@@ -135,11 +135,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1688220547,
-        "narHash": "sha256-cNKKLPaEOxd6t22Mt3tHGubyylbKGdoi2A3QkMTKes0=",
+        "lastModified": 1690846837,
+        "narHash": "sha256-ZZ8YPOEdZG0zz61U4sfUAx28oEdqLdtG1iWTTH/98uc=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "89d10f8adce369a80e046c2fd56d1e7b7507bb5b",
+        "rev": "4fd794d3df88735dcf9662155d77b08a2e2dde29",
         "type": "github"
       },
       "original": {
@@ -156,11 +156,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1688255021,
-        "narHash": "sha256-BPsKHa/7VY8iUL3QmNSH14qlnLrxp63E3N9o4JMaS90=",
+        "lastModified": 1690805527,
+        "narHash": "sha256-CGAiP0bPPDdsbYQdfAPYl3lIMQbJuyxG4tzGgU1BKUE=",
         "owner": "nix-community",
         "repo": "nixd",
-        "rev": "84f86fec537f31d53fea2c74a408fb596ddbfd90",
+        "rev": "c4f71ee237124c41313e9c13a1b2c033ed26f70c",
         "type": "github"
       },
       "original": {
@@ -171,11 +171,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1686838567,
-        "narHash": "sha256-aqKCUD126dRlVSKV6vWuDCitfjFrZlkwNuvj5LtjRRU=",
+        "lastModified": 1690704397,
+        "narHash": "sha256-sgIWjcz0e+x87xlKg324VtHgH55J5rIuFF0ZWRDvQoE=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "429f232fe1dc398c5afea19a51aad6931ee0fb89",
+        "rev": "96e5a0a0e8568c998135ea05575a9ed2c87f5492",
         "type": "github"
       },
       "original": {
@@ -187,11 +187,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1689679375,
-        "narHash": "sha256-LHUC52WvyVDi9PwyL1QCpaxYWBqp4ir4iL6zgOkmcb8=",
+        "lastModified": 1690789960,
+        "narHash": "sha256-3K+2HuyGTiJUSZNJxXXvc0qj4xFx1FHC/ItYtEa7/Xs=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "684c17c429c42515bafb3ad775d2a710947f3d67",
+        "rev": "fb942492b7accdee4e6d17f5447091c65897dde4",
         "type": "github"
       },
       "original": {
@@ -237,11 +237,11 @@
     },
     "nixpkgs-stable_2": {
       "locked": {
-        "lastModified": 1688256355,
-        "narHash": "sha256-/E+OSabu4ii5+ccWff2k4vxDsXYhpc4hwnm0s6JOz7Y=",
+        "lastModified": 1690066826,
+        "narHash": "sha256-6L2qb+Zc0BFkh72OS9uuX637gniOjzU6qCDBpjB2LGY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f553c016a31277246f8d3724d3b1eee5e8c0842c",
+        "rev": "ce45b591975d070044ca24e3003c830d26fea1c8",
         "type": "github"
       },
       "original": {
@@ -253,11 +253,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1688272984,
-        "narHash": "sha256-RzQzZ4msqK2ECgJn0fqgujhoPJvAy8LsbGfv3KByf1U=",
+        "lastModified": 1690847333,
+        "narHash": "sha256-pgjuITHqYfBwKiOOsfWwtKTqp7w/r+Xuu6FbpO7wdLA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c2acdb273bef64edc5f786c53381f736690b6fbf",
+        "rev": "8d0d16d334c39ae68306384c1476aa89c53ce3a4",
         "type": "github"
       },
       "original": {
@@ -315,11 +315,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1688268466,
-        "narHash": "sha256-fArazqgYyEFiNcqa136zVYXihuqzRHNOOeVICayU2Yg=",
+        "lastModified": 1690199016,
+        "narHash": "sha256-yTLL72q6aqGmzHq+C3rDp3rIjno7EJZkFLof6Ika7cE=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "5ed3c22c1fa0515e037e36956a67fe7e32c92957",
+        "rev": "c36df4fe4bf4bb87759b1891cab21e7a05219500",
         "type": "github"
       },
       "original": {
@@ -350,11 +350,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1688026376,
-        "narHash": "sha256-qJmkr9BWDpqblk4E9/rCsAEl39y2n4Ycw6KRopvpUcY=",
+        "lastModified": 1689620039,
+        "narHash": "sha256-BtNwghr05z7k5YMdq+6nbue+nEalvDepuA7qdQMAKoQ=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "df3f32b0cc253dfc7009b7317e8f0e7ccd70b1cf",
+        "rev": "719c2977f958c41fa60a928e2fbc50af14844114",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<pre># Update report
# flake lock update
[K[Kwarning: updating lock file '/home/runner/work/nixos/nixos/flake.lock':
• Updated input 'attic':
    'github:zhaofengli/attic/4fedffe6a1020edfcfa7bef18d21321d4983b3a7' (2023-06-13)
  → 'github:zhaofengli/attic/4902d57f5dae8ec660ee9ee14c45c2192f9fe8b1' (2023-07-15)
• Updated input 'disko':
    'github:nix-community/disko/8002e7cb899bc2a02a2ebfb7f999fcd7c18b92a1' (2023-06-28)
  → 'github:nix-community/disko/4015740375676402a2ee6adebc3c30ea625b9a94' (2023-07-30)
• Updated input 'flake-utils':
    'github:numtide/flake-utils/dbabf0ca0c0c4bce6ea5eaf65af5cb694d2082c7' (2023-06-25)
  → 'github:numtide/flake-utils/919d646de7be200f3bf08cb76ae1f09402b6f9b4' (2023-07-11)
• Updated input 'home-manager':
    'github:nix-community/home-manager/89d10f8adce369a80e046c2fd56d1e7b7507bb5b' (2023-07-01)
  → 'github:nix-community/home-manager/4fd794d3df88735dcf9662155d77b08a2e2dde29' (2023-07-31)
• Updated input 'nixd':
    'github:nix-community/nixd/84f86fec537f31d53fea2c74a408fb596ddbfd90' (2023-07-01)
  → 'github:nix-community/nixd/c4f71ee237124c41313e9c13a1b2c033ed26f70c' (2023-07-31)
• Updated input 'nixos-hardware':
    'github:NixOS/nixos-hardware/429f232fe1dc398c5afea19a51aad6931ee0fb89' (2023-06-15)
  → 'github:NixOS/nixos-hardware/96e5a0a0e8568c998135ea05575a9ed2c87f5492' (2023-07-30)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/684c17c429c42515bafb3ad775d2a710947f3d67' (2023-07-18)
  → 'github:nixos/nixpkgs/fb942492b7accdee4e6d17f5447091c65897dde4' (2023-07-31)
• Updated input 'nur':
    'github:nix-community/NUR/c2acdb273bef64edc5f786c53381f736690b6fbf' (2023-07-02)
  → 'github:nix-community/NUR/8d0d16d334c39ae68306384c1476aa89c53ce3a4' (2023-07-31)
• Updated input 'sops-nix':
    'github:Mic92/sops-nix/5ed3c22c1fa0515e037e36956a67fe7e32c92957' (2023-07-02)
  → 'github:Mic92/sops-nix/c36df4fe4bf4bb87759b1891cab21e7a05219500' (2023-07-24)
• Updated input 'sops-nix/nixpkgs-stable':
    'github:NixOS/nixpkgs/f553c016a31277246f8d3724d3b1eee5e8c0842c' (2023-07-02)
  → 'github:NixOS/nixpkgs/ce45b591975d070044ca24e3003c830d26fea1c8' (2023-07-22)
• Updated input 'treefmt-nix':
    'github:numtide/treefmt-nix/df3f32b0cc253dfc7009b7317e8f0e7ccd70b1cf' (2023-06-29)
  → 'github:numtide/treefmt-nix/719c2977f958c41fa60a928e2fbc50af14844114' (2023-07-17)
warning: Git tree '/home/runner/work/nixos/nixos' is dirty

# nvfetcher update
# CheckGit
    url: https://github.com/elken/cape-yasnippet
    branch: 
# CheckGit
    url: https://github.com/MetaCubeX/Yacd-meta
    branch: gh-pages
# FetchGitHub
  owner: elken
  repo: cape-yasnippet
  rev: ed06497466718fc6de43606cbc3a6ac9f237008a
  deepClone: False
  fetchSubmodules: False
  leaveDotGit: False
# FetchGitHub
  owner: MetaCubeX
  repo: Yacd-meta
  rev: fa8f6c1a27b37c17cd89b9255a584d21f6ddb7bd
  deepClone: False
  fetchSubmodules: False
  leaveDotGit: False
# GetGitCommitDate
  url: https://github.com/elken/cape-yasnippet
  rev: ed06497466718fc6de43606cbc3a6ac9f237008a
  format: 
# CheckArchLinux: rime-pinyin-zhwiki
  NvcheckerOptions
    stripPrefix: 0.2.4.
# GetGitCommitDate
  url: https://github.com/MetaCubeX/Yacd-meta
  rev: fa8f6c1a27b37c17cd89b9255a584d21f6ddb7bd
  format: 
# CheckGitHubRelease
    owner: GloriousEggroll
    repo: proton-ge-custom
# FetchUrl
  url: https://github.com/GloriousEggroll/proton-ge-custom/releases/download/GE-Proton8-9/GE-Proton8-9.tar.gz
# FetchUrl
  url: https://github.com/felixonmars/fcitx5-pinyin-zhwiki/releases/download/0.2.4/zhwiki-20230728.dict.yaml
# CheckGit
    url: https://github.com/Jovian-Experiments/Jovian-NixOS
    branch: 
# FetchGitHub
  owner: Jovian-Experiments
  repo: Jovian-NixOS
  rev: 9758792434ae5693cb6c70454f534a47b4fe5241
  deepClone: False
  fetchSubmodules: False
  leaveDotGit: False
# GetGitCommitDate
  url: https://github.com/Jovian-Experiments/Jovian-NixOS
  rev: 9758792434ae5693cb6c70454f534a47b4fe5241
  format: 
Changes:
cape-yasnippet: ad8c27c2f748b410e7dd568927e99081f87b98b9 → ed06497466718fc6de43606cbc3a6ac9f237008a
yacd-meta: 2d0c52cecf9ee7ed8446d2fa240291ef83facbde → fa8f6c1a27b37c17cd89b9255a584d21f6ddb7bd
rime-pinyin-zhwiki: 20230605 → 20230728
jovian-nixos: 449faaa41e55c504d2068f2a77c91a0dbc5b191d → 9758792434ae5693cb6c70454f534a47b4fe5241
proton-ge-custom: GE-Proton8-4 → GE-Proton8-9


</pre>