### PR TITLE
Update flake.lock and nvfetcher sources

### DIFF
--- a/_sources/generated.json
+++ b/_sources/generated.json
@@ -1,7 +1,7 @@
 {
     "cape-yasnippet": {
         "cargoLocks": null,
-        "date": "2023-08-13",
+        "date": "2023-10-24",
         "extract": null,
         "name": "cape-yasnippet",
         "passthru": null,
@@ -13,11 +13,11 @@
             "name": null,
             "owner": "elken",
             "repo": "cape-yasnippet",
-            "rev": "40654214db7a44db3a99321447632b43a10fae57",
-            "sha256": "sha256-w5gckpREvV4ET6+/wSgul0wPC42Xeb5B7rFmuuSh3M8=",
+            "rev": "a0a6b1c2bb6decdad5cf9b74202f0042f494a6ab",
+            "sha256": "sha256-KDvtBc+oiu6IQ9V8rudcE5AKEobmtCJYRpsuJgZt8zs=",
             "type": "github"
         },
-        "version": "40654214db7a44db3a99321447632b43a10fae57"
+        "version": "a0a6b1c2bb6decdad5cf9b74202f0042f494a6ab"
     },
     "jovian-nixos": {
         "cargoLocks": null,
@@ -41,7 +41,7 @@
     },
     "metacubexd": {
         "cargoLocks": null,
-        "date": "2023-09-12",
+        "date": "2023-10-30",
         "extract": null,
         "name": "metacubexd",
         "passthru": null,
@@ -53,11 +53,11 @@
             "name": null,
             "owner": "MetaCubeX",
             "repo": "metacubexd",
-            "rev": "2bb2ad9fa9bab3d27b3494d9df92c8a130f14659",
-            "sha256": "sha256-kWajuFOVHGZNCGDngpJphY/OthYFTRApkaqxerxTT/U=",
+            "rev": "62cf8c61f92653069e84dc8c77d9afb64f5213be",
+            "sha256": "sha256-+/Nh18Js/dv98WR8sJ2PSfqSaahQIG+gBW9aWFbN9DM=",
             "type": "github"
         },
-        "version": "2bb2ad9fa9bab3d27b3494d9df92c8a130f14659"
+        "version": "62cf8c61f92653069e84dc8c77d9afb64f5213be"
     },
     "proton-ge-custom": {
         "cargoLocks": null,
@@ -68,11 +68,11 @@
         "pinned": false,
         "src": {
             "name": null,
-            "sha256": "sha256-OPwmVxBGaWo51pDJcqvxvZ8qxMH8X0DwZTpwiKbdx/I=",
+            "sha256": "sha256-JBS1CFdiOCKLWwavx/o+TFHUPFAA/wygrFcyO9SK9cc=",
             "type": "url",
-            "url": "https://github.com/GloriousEggroll/proton-ge-custom/releases/download/GE-Proton8-4/GE-Proton8-4.tar.gz"
+            "url": "https://github.com/GloriousEggroll/proton-ge-custom/releases/download/GE-Proton8-22/GE-Proton8-22.tar.gz"
         },
-        "version": "GE-Proton8-4"
+        "version": "GE-Proton8-22"
     },
     "rime-pinyin-zhwiki": {
         "cargoLocks": null,
@@ -83,15 +83,15 @@
         "pinned": false,
         "src": {
             "name": null,
-            "sha256": "sha256-SB2TcvJb/7D3cO3NG34QecMxWMAFwwHCSr3sKHLZa3o=",
+            "sha256": "sha256-6KQL7Ef+EqK5RIw2r+qox2rmyhLg07H3tiXG3GIcO8w=",
             "type": "url",
-            "url": "https://github.com/felixonmars/fcitx5-pinyin-zhwiki/releases/download/0.2.4/zhwiki-20230605.dict.yaml"
+            "url": "https://github.com/felixonmars/fcitx5-pinyin-zhwiki/releases/download/0.2.4/zhwiki-20231016.dict.yaml"
         },
-        "version": "20230605"
+        "version": "20231016"
     },
     "yacd-meta": {
         "cargoLocks": null,
-        "date": "2023-06-29",
+        "date": "2023-10-24",
         "extract": null,
         "name": "yacd-meta",
         "passthru": null,
@@ -103,10 +103,10 @@
             "name": null,
             "owner": "MetaCubeX",
             "repo": "Yacd-meta",
-            "rev": "2d0c52cecf9ee7ed8446d2fa240291ef83facbde",
-            "sha256": "sha256-Pi1LV+DnBiFqcelPz/F6Ip2wH+GC87vE+9H4nCaWlBU=",
+            "rev": "d94b9c7283dcc41b7ab0a19c3c39d6f1846526d8",
+            "sha256": "sha256-8ePycNHG6bV0L5vurdC79IJtYN/OU1HxKjmsvs6CCaI=",
             "type": "github"
         },
-        "version": "2d0c52cecf9ee7ed8446d2fa240291ef83facbde"
+        "version": "d94b9c7283dcc41b7ab0a19c3c39d6f1846526d8"
     }
 }

--- a/_sources/generated.nix
+++ b/_sources/generated.nix
@@ -3,15 +3,15 @@
 {
   cape-yasnippet = {
     pname = "cape-yasnippet";
-    version = "40654214db7a44db3a99321447632b43a10fae57";
+    version = "a0a6b1c2bb6decdad5cf9b74202f0042f494a6ab";
     src = fetchFromGitHub {
       owner = "elken";
       repo = "cape-yasnippet";
-      rev = "40654214db7a44db3a99321447632b43a10fae57";
+      rev = "a0a6b1c2bb6decdad5cf9b74202f0042f494a6ab";
       fetchSubmodules = false;
-      sha256 = "sha256-w5gckpREvV4ET6+/wSgul0wPC42Xeb5B7rFmuuSh3M8=";
+      sha256 = "sha256-KDvtBc+oiu6IQ9V8rudcE5AKEobmtCJYRpsuJgZt8zs=";
     };
-    date = "2023-08-13";
+    date = "2023-10-24";
   };
   jovian-nixos = {
     pname = "jovian-nixos";
@@ -27,42 +27,42 @@
   };
   metacubexd = {
     pname = "metacubexd";
-    version = "2bb2ad9fa9bab3d27b3494d9df92c8a130f14659";
+    version = "62cf8c61f92653069e84dc8c77d9afb64f5213be";
     src = fetchFromGitHub {
       owner = "MetaCubeX";
       repo = "metacubexd";
-      rev = "2bb2ad9fa9bab3d27b3494d9df92c8a130f14659";
+      rev = "62cf8c61f92653069e84dc8c77d9afb64f5213be";
       fetchSubmodules = false;
-      sha256 = "sha256-kWajuFOVHGZNCGDngpJphY/OthYFTRApkaqxerxTT/U=";
+      sha256 = "sha256-+/Nh18Js/dv98WR8sJ2PSfqSaahQIG+gBW9aWFbN9DM=";
     };
-    date = "2023-09-12";
+    date = "2023-10-30";
   };
   proton-ge-custom = {
     pname = "proton-ge-custom";
-    version = "GE-Proton8-4";
+    version = "GE-Proton8-22";
     src = fetchurl {
-      url = "https://github.com/GloriousEggroll/proton-ge-custom/releases/download/GE-Proton8-4/GE-Proton8-4.tar.gz";
-      sha256 = "sha256-OPwmVxBGaWo51pDJcqvxvZ8qxMH8X0DwZTpwiKbdx/I=";
+      url = "https://github.com/GloriousEggroll/proton-ge-custom/releases/download/GE-Proton8-22/GE-Proton8-22.tar.gz";
+      sha256 = "sha256-JBS1CFdiOCKLWwavx/o+TFHUPFAA/wygrFcyO9SK9cc=";
     };
   };
   rime-pinyin-zhwiki = {
     pname = "rime-pinyin-zhwiki";
-    version = "20230605";
+    version = "20231016";
     src = fetchurl {
-      url = "https://github.com/felixonmars/fcitx5-pinyin-zhwiki/releases/download/0.2.4/zhwiki-20230605.dict.yaml";
-      sha256 = "sha256-SB2TcvJb/7D3cO3NG34QecMxWMAFwwHCSr3sKHLZa3o=";
+      url = "https://github.com/felixonmars/fcitx5-pinyin-zhwiki/releases/download/0.2.4/zhwiki-20231016.dict.yaml";
+      sha256 = "sha256-6KQL7Ef+EqK5RIw2r+qox2rmyhLg07H3tiXG3GIcO8w=";
     };
   };
   yacd-meta = {
     pname = "yacd-meta";
-    version = "2d0c52cecf9ee7ed8446d2fa240291ef83facbde";
+    version = "d94b9c7283dcc41b7ab0a19c3c39d6f1846526d8";
     src = fetchFromGitHub {
       owner = "MetaCubeX";
       repo = "Yacd-meta";
-      rev = "2d0c52cecf9ee7ed8446d2fa240291ef83facbde";
+      rev = "d94b9c7283dcc41b7ab0a19c3c39d6f1846526d8";
       fetchSubmodules = false;
-      sha256 = "sha256-Pi1LV+DnBiFqcelPz/F6Ip2wH+GC87vE+9H4nCaWlBU=";
+      sha256 = "sha256-8ePycNHG6bV0L5vurdC79IJtYN/OU1HxKjmsvs6CCaI=";
     };
-    date = "2023-06-29";
+    date = "2023-10-24";
   };
 }

--- a/flake.lock
+++ b/flake.lock
@@ -13,11 +13,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1692225040,
-        "narHash": "sha256-jbQNvkgWGioiC6S39dZVyn6us8p/DlEvm5hQKEYkzDU=",
+        "lastModified": 1698258239,
+        "narHash": "sha256-qnhoYYIJ0L/P7H/f56lQUEvpzNlXh4sxuHpRERV+B44=",
         "owner": "zhaofengli",
         "repo": "attic",
-        "rev": "b43d12082e34bceb26038bdad0438fd68804cfcd",
+        "rev": "e9918bc6be268da6fa97af6ced15193d8a0421c0",
         "type": "github"
       },
       "original": {
@@ -63,11 +63,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1687968164,
-        "narHash": "sha256-L9jr2zCB6NIaBE3towusjGBigsnE2pMID8wBGkYbTS4=",
+        "lastModified": 1698422527,
+        "narHash": "sha256-SDu3Xg263t3oXIyTaH0buOvFnKIDeZsvKDBtOz+jRbs=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "8002e7cb899bc2a02a2ebfb7f999fcd7c18b92a1",
+        "rev": "944d338d24a9d043a3f7461c30ee6cfe4f9cca30",
         "type": "github"
       },
       "original": {
@@ -131,11 +131,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1687709756,
-        "narHash": "sha256-Y5wKlQSkgEK2weWdOu4J3riRd+kV/VCgHsqLNTTWQ/0=",
+        "lastModified": 1694529238,
+        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "dbabf0ca0c0c4bce6ea5eaf65af5cb694d2082c7",
+        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
         "type": "github"
       },
       "original": {
@@ -151,11 +151,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1688220547,
-        "narHash": "sha256-cNKKLPaEOxd6t22Mt3tHGubyylbKGdoi2A3QkMTKes0=",
+        "lastModified": 1698795315,
+        "narHash": "sha256-fF5ScAWLMHXOuqsbLSG137kS1D+gr9JPtm4H2c4yBbU=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "89d10f8adce369a80e046c2fd56d1e7b7507bb5b",
+        "rev": "9bc7d84b8213255ecd5eb6299afdb77c36ece71d",
         "type": "github"
       },
       "original": {
@@ -172,11 +172,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1688255021,
-        "narHash": "sha256-BPsKHa/7VY8iUL3QmNSH14qlnLrxp63E3N9o4JMaS90=",
+        "lastModified": 1697038389,
+        "narHash": "sha256-hbzFPXyQQxJObRdb+CsylUXii29UfFV7866WWgWYs6Y=",
         "owner": "nix-community",
         "repo": "nixd",
-        "rev": "84f86fec537f31d53fea2c74a408fb596ddbfd90",
+        "rev": "29904e121cc775e7caaf4fffa6bc7da09376a43b",
         "type": "github"
       },
       "original": {
@@ -187,11 +187,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1686838567,
-        "narHash": "sha256-aqKCUD126dRlVSKV6vWuDCitfjFrZlkwNuvj5LtjRRU=",
+        "lastModified": 1698053470,
+        "narHash": "sha256-sP8D/41UiwC2qn0X40oi+DfuVzNHMROqIWdSdCI/AYA=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "429f232fe1dc398c5afea19a51aad6931ee0fb89",
+        "rev": "80d98a7d55c6e27954a166cb583a41325e9512d7",
         "type": "github"
       },
       "original": {
@@ -203,11 +203,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1693377291,
-        "narHash": "sha256-vYGY9bnqEeIncNarDZYhm6KdLKgXMS+HA2mTRaWEc80=",
+        "lastModified": 1698611440,
+        "narHash": "sha256-jPjHjrerhYDy3q9+s5EAsuhyhuknNfowY6yt6pjn9pc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e7f38be3775bab9659575f192ece011c033655f0",
+        "rev": "0cbe9f69c234a7700596e943bfae7ef27a31b735",
         "type": "github"
       },
       "original": {
@@ -253,11 +253,11 @@
     },
     "nixpkgs-stable_2": {
       "locked": {
-        "lastModified": 1688256355,
-        "narHash": "sha256-/E+OSabu4ii5+ccWff2k4vxDsXYhpc4hwnm0s6JOz7Y=",
+        "lastModified": 1698544399,
+        "narHash": "sha256-vhRmPyEyoPkrXF2iykBsWHA05MIaOSmMRLMF7Hul6+s=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f553c016a31277246f8d3724d3b1eee5e8c0842c",
+        "rev": "d87c5d8c41c9b3b39592563242f3a448b5cc4bc9",
         "type": "github"
       },
       "original": {
@@ -269,11 +269,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1693893490,
-        "narHash": "sha256-j0czkuz6Ps9b3A0JDMVKATj6lJ9aggKklRcA+jZ5i/Y=",
+        "lastModified": 1698795974,
+        "narHash": "sha256-1CZZY3nvgo46hdSP9Z+0PDvPpTOuaDh6xfKldZGgJ3M=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "102078874cdd2bad7d4701ad49404985172193b0",
+        "rev": "4cf69a3615da6869af93d17f784404f821a7d7b1",
         "type": "github"
       },
       "original": {
@@ -293,11 +293,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1692372415,
-        "narHash": "sha256-QVrvyRf2LKdvnElp50sORKWmyP8KBVDKL7mTXvSNDqU=",
+        "lastModified": 1693539235,
+        "narHash": "sha256-ACmCq1+RnVq+EB7yeN6fThUR3cCJZb6lKEfv937WG84=",
         "owner": "berberman",
         "repo": "nvfetcher",
-        "rev": "447973723f6e284934d3cf5f81ca4cfbf4462aef",
+        "rev": "2bcf73dea96497ac9c36ed320b457caa705f9485",
         "type": "github"
       },
       "original": {
@@ -356,11 +356,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1688268466,
-        "narHash": "sha256-fArazqgYyEFiNcqa136zVYXihuqzRHNOOeVICayU2Yg=",
+        "lastModified": 1698548647,
+        "narHash": "sha256-7c03OjBGqnwDW0FBaBc+NjfEBxMkza+dxZGJPyIzfFE=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "5ed3c22c1fa0515e037e36956a67fe7e32c92957",
+        "rev": "632c3161a6cc24142c8e3f5529f5d81042571165",
         "type": "github"
       },
       "original": {
@@ -391,11 +391,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1688026376,
-        "narHash": "sha256-qJmkr9BWDpqblk4E9/rCsAEl39y2n4Ycw6KRopvpUcY=",
+        "lastModified": 1698438538,
+        "narHash": "sha256-AWxaKTDL3MtxaVTVU5lYBvSnlspOS0Fjt8GxBgnU0Do=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "df3f32b0cc253dfc7009b7317e8f0e7ccd70b1cf",
+        "rev": "5deb8dc125a9f83b65ca86cf0c8167c46593e0b1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<pre># Update report
# flake lock update
[K[Kwarning: updating lock file '/home/runner/work/nixos/nixos/flake.lock':
• Updated input 'attic':
    'github:zhaofengli/attic/b43d12082e34bceb26038bdad0438fd68804cfcd' (2023-08-16)
  → 'github:zhaofengli/attic/e9918bc6be268da6fa97af6ced15193d8a0421c0' (2023-10-25)
• Updated input 'disko':
    'github:nix-community/disko/8002e7cb899bc2a02a2ebfb7f999fcd7c18b92a1' (2023-06-28)
  → 'github:nix-community/disko/944d338d24a9d043a3f7461c30ee6cfe4f9cca30' (2023-10-27)
• Updated input 'flake-utils':
    'github:numtide/flake-utils/dbabf0ca0c0c4bce6ea5eaf65af5cb694d2082c7' (2023-06-25)
  → 'github:numtide/flake-utils/ff7b65b44d01cf9ba6a71320833626af21126384' (2023-09-12)
• Updated input 'home-manager':
    'github:nix-community/home-manager/89d10f8adce369a80e046c2fd56d1e7b7507bb5b' (2023-07-01)
  → 'github:nix-community/home-manager/9bc7d84b8213255ecd5eb6299afdb77c36ece71d' (2023-10-31)
• Updated input 'nixd':
    'github:nix-community/nixd/84f86fec537f31d53fea2c74a408fb596ddbfd90' (2023-07-01)
  → 'github:nix-community/nixd/29904e121cc775e7caaf4fffa6bc7da09376a43b' (2023-10-11)
• Updated input 'nixos-hardware':
    'github:NixOS/nixos-hardware/429f232fe1dc398c5afea19a51aad6931ee0fb89' (2023-06-15)
  → 'github:NixOS/nixos-hardware/80d98a7d55c6e27954a166cb583a41325e9512d7' (2023-10-23)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/e7f38be3775bab9659575f192ece011c033655f0' (2023-08-30)
  → 'github:nixos/nixpkgs/0cbe9f69c234a7700596e943bfae7ef27a31b735' (2023-10-29)
• Updated input 'nur':
    'github:nix-community/NUR/102078874cdd2bad7d4701ad49404985172193b0' (2023-09-05)
  → 'github:nix-community/NUR/4cf69a3615da6869af93d17f784404f821a7d7b1' (2023-10-31)
• Updated input 'nvfetcher':
    'github:berberman/nvfetcher/447973723f6e284934d3cf5f81ca4cfbf4462aef' (2023-08-18)
  → 'github:berberman/nvfetcher/2bcf73dea96497ac9c36ed320b457caa705f9485' (2023-09-01)
• Updated input 'sops-nix':
    'github:Mic92/sops-nix/5ed3c22c1fa0515e037e36956a67fe7e32c92957' (2023-07-02)
  → 'github:Mic92/sops-nix/632c3161a6cc24142c8e3f5529f5d81042571165' (2023-10-29)
• Updated input 'sops-nix/nixpkgs-stable':
    'github:NixOS/nixpkgs/f553c016a31277246f8d3724d3b1eee5e8c0842c' (2023-07-02)
  → 'github:NixOS/nixpkgs/d87c5d8c41c9b3b39592563242f3a448b5cc4bc9' (2023-10-29)
• Updated input 'treefmt-nix':
    'github:numtide/treefmt-nix/df3f32b0cc253dfc7009b7317e8f0e7ccd70b1cf' (2023-06-29)
  → 'github:numtide/treefmt-nix/5deb8dc125a9f83b65ca86cf0c8167c46593e0b1' (2023-10-27)
warning: Git tree '/home/runner/work/nixos/nixos' is dirty

# nvfetcher update
# CheckGit
    url: https://github.com/MetaCubeX/Yacd-meta
    branch: gh-pages
# CheckGitHubRelease
    owner: GloriousEggroll
    repo: proton-ge-custom
# FetchUrl
  url: https://github.com/GloriousEggroll/proton-ge-custom/releases/download/GE-Proton8-22/GE-Proton8-22.tar.gz
# FetchGitHub
  owner: MetaCubeX
  repo: Yacd-meta
  rev: d94b9c7283dcc41b7ab0a19c3c39d6f1846526d8
  deepClone: False
  fetchSubmodules: False
  leaveDotGit: False
# GetGitCommitDate
  url: https://github.com/MetaCubeX/Yacd-meta
  rev: d94b9c7283dcc41b7ab0a19c3c39d6f1846526d8
  format: 
# CheckGit
    url: https://github.com/elken/cape-yasnippet
    branch: 
# CheckGit
    url: https://github.com/sg-qwt/Jovian-NixOS
    branch: devdev
# CheckArchLinux: rime-pinyin-zhwiki
  NvcheckerOptions
    stripPrefix: 0.2.4.
# FetchUrl
  url: https://github.com/felixonmars/fcitx5-pinyin-zhwiki/releases/download/0.2.4/zhwiki-20231016.dict.yaml
# CheckGit
    url: https://github.com/MetaCubeX/metacubexd
    branch: gh-pages
# FetchGitHub
  owner: elken
  repo: cape-yasnippet
  rev: a0a6b1c2bb6decdad5cf9b74202f0042f494a6ab
  deepClone: False
  fetchSubmodules: False
  leaveDotGit: False
# GetGitCommitDate
  url: https://github.com/elken/cape-yasnippet
  rev: a0a6b1c2bb6decdad5cf9b74202f0042f494a6ab
  format: 
# FetchGitHub
  owner: sg-qwt
  repo: Jovian-NixOS
  rev: 8501772997eae3ca4be3584ad4e93d448b0224e5
  deepClone: False
  fetchSubmodules: False
  leaveDotGit: False
# GetGitCommitDate
  url: https://github.com/sg-qwt/Jovian-NixOS
  rev: 8501772997eae3ca4be3584ad4e93d448b0224e5
  format: 
# FetchGitHub
  owner: MetaCubeX
  repo: metacubexd
  rev: 62cf8c61f92653069e84dc8c77d9afb64f5213be
  deepClone: False
  fetchSubmodules: False
  leaveDotGit: False
# GetGitCommitDate
  url: https://github.com/MetaCubeX/metacubexd
  rev: 62cf8c61f92653069e84dc8c77d9afb64f5213be
  format: 
Changes:
yacd-meta: 2d0c52cecf9ee7ed8446d2fa240291ef83facbde → d94b9c7283dcc41b7ab0a19c3c39d6f1846526d8
rime-pinyin-zhwiki: 20230605 → 20231016
cape-yasnippet: 40654214db7a44db3a99321447632b43a10fae57 → a0a6b1c2bb6decdad5cf9b74202f0042f494a6ab
proton-ge-custom: GE-Proton8-4 → GE-Proton8-22
metacubexd: 2bb2ad9fa9bab3d27b3494d9df92c8a130f14659 → 62cf8c61f92653069e84dc8c77d9afb64f5213be


</pre>