### PR TITLE
Update flake.lock sources

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -53,11 +53,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1726560853,
-        "narHash": "sha256-X6rJYSESBVr3hBoH0WbKE5KvhPU5bloyZ2L4K60/fPQ=",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {
@@ -73,11 +73,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1732397793,
-        "narHash": "sha256-2jaf/zkug22hzlldm1PKdKJLVKgdjVXbf47SF+5mroU=",
+        "lastModified": 1732884235,
+        "narHash": "sha256-r8j6R3nrvwbT1aUp4EPQ1KC7gm0pu9VcV1aNaB+XG6Q=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "92fef254a9071fa41a13908281284e6a62b9c92e",
+        "rev": "819f682269f4e002884702b87e445c82840c68f2",
         "type": "github"
       },
       "original": {
@@ -94,11 +94,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1730652030,
-        "narHash": "sha256-uTToUpFphR9ywc+DQUD/8hmboOMFV1lBVFf/ztzdn6A=",
+        "lastModified": 1732739177,
+        "narHash": "sha256-iL32+TA/8geCzcL1r3uthrH/GPvbUak5QE++WJUkaiI=",
         "owner": "Jovian-Experiments",
         "repo": "Jovian-NixOS",
-        "rev": "e74e57a37de55ecfdc62f49fe5a7463b2a52499a",
+        "rev": "8d7b2149e618696d5100c2683af1ffa893f02a75",
         "type": "github"
       },
       "original": {
@@ -147,11 +147,11 @@
     },
     "nixpkgs-latest": {
       "locked": {
-        "lastModified": 1732014248,
-        "narHash": "sha256-y/MEyuJ5oBWrWAic/14LaIr/u5E0wRVzyYsouYY3W6w=",
+        "lastModified": 1732837521,
+        "narHash": "sha256-jNRNr49UiuIwaarqijgdTR2qLPifxsVhlJrKzQ8XUIE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
+        "rev": "970e93b9f82e2a0f3675757eb0bfc73297cc6370",
         "type": "github"
       },
       "original": {
@@ -196,11 +196,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1732186149,
-        "narHash": "sha256-N9JGWe/T8BC0Tss2Cv30plvZUYoiRmykP7ZdY2on2b0=",
+        "lastModified": 1732575825,
+        "narHash": "sha256-xtt95+c7OUMoqZf4OvA/7AemiH3aVuWHQbErYQoPwFk=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "53c853fb1a7e4f25f68805ee25c83d5de18dc699",
+        "rev": "3433ea14fbd9e6671d0ff0dd45ed15ee4c156ffa",
         "type": "github"
       },
       "original": {
@@ -252,11 +252,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1730321837,
-        "narHash": "sha256-vK+a09qq19QNu2MlLcvN4qcRctJbqWkX7ahgPZ/+maI=",
+        "lastModified": 1732894027,
+        "narHash": "sha256-2qbdorpq0TXHBWbVXaTqKoikN4bqAtAplTwGuII+oAc=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "746901bb8dba96d154b66492a29f5db0693dbfcc",
+        "rev": "6209c381904cab55796c5d7350e89681d3b2a8ef",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<pre># Update report
# flake lock update
[K[Kwarning: updating lock file '/home/runner/work/nixos/nixos/flake.lock':
• Updated input 'attic':
    'github:zhaofengli/attic/e9918bc6be268da6fa97af6ced15193d8a0421c0' (2023-10-25)
  → 'github:zhaofengli/attic/fbe252a5c21febbe920c025560cbd63b20e24f3b' (2024-01-18)
• Updated input 'attic/crane':
    'github:ipetkov/crane/105e27adb70a9890986b6d543a67761cbc1964a2' (2023-03-04)
  → 'github:ipetkov/crane/7195c00c272fdd92fc74e7d5a0a2844b9fadb2fb' (2023-12-18)
• Removed input 'attic/crane/flake-compat'
• Removed input 'attic/crane/flake-utils'
• Removed input 'attic/crane/rust-overlay'
• Removed input 'attic/crane/rust-overlay/flake-utils'
• Removed input 'attic/crane/rust-overlay/nixpkgs'
• Updated input 'attic/nixpkgs-stable':
    'github:NixOS/nixpkgs/3e01645c40b92d29f3ae76344a6d654986a91a91' (2023-05-25)
  → 'github:NixOS/nixpkgs/1e2e384c5b7c50dbf8e9c441a9e58d85f408b01f' (2023-12-17)
• Updated input 'chugou':
    'github:sg-qwt/chugou/95fbca78e32e93625c782dcc8ced976300b0df42' (2024-01-31)
  → 'github:sg-qwt/chugou/da219e2debc2158fc6c8eb27dfb408e9ce72961e' (2024-01-31)
• Updated input 'flake-utils':
    'github:numtide/flake-utils/ff7b65b44d01cf9ba6a71320833626af21126384' (2023-09-12)
  → 'github:numtide/flake-utils/1ef2e671c3b0c19053962c07dbda38332dcebf26' (2024-01-15)
• Updated input 'home-manager':
    'github:nix-community/home-manager/c36cb65c4a0ba17ab9262ab3c30920429348746c' (2024-01-04)
  → 'github:nix-community/home-manager/d634c3abafa454551f2083b054cd95c3f287be61' (2024-01-28)
• Updated input 'jovian':
    'github:Jovian-Experiments/Jovian-NixOS/1962ff3135b1468ae473a196da01d0ebf38c144e' (2024-01-04)
  → 'github:Jovian-Experiments/Jovian-NixOS/e2c026d8efea340d2a2dcc56775212979dd51ef2' (2024-01-29)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/bd645e8668ec6612439a9ee7e71f7eac4099d4f6' (2024-01-02)
  → 'github:nixos/nixpkgs/97b17f32362e475016f942bbdfda4a4a72a8a652' (2024-01-29)
• Updated input 'nur':
    'github:nix-community/NUR/574dd1188450450d2d3c969a2312b3e5f99a53fb' (2023-11-14)
  → 'github:nix-community/NUR/006d88080f6b231ea268bb3298f23040eaa8cd1e' (2024-01-31)
• Updated input 'sops-nix':
    'github:Mic92/sops-nix/0e3a94167dcd10a47b89141f35b2ff9e04b34c46' (2023-11-14)
  → 'github:Mic92/sops-nix/73bf36912e31a6b21af6e0f39218e067283c67ef' (2024-01-28)
• Updated input 'sops-nix/nixpkgs-stable':
    'github:NixOS/nixpkgs/9502d0245983bb233da8083b55d60d96fd3c29ff' (2023-11-12)
  → 'github:NixOS/nixpkgs/9a333eaa80901efe01df07eade2c16d183761fa3' (2024-01-22)
• Updated input 'treefmt-nix':
    'github:numtide/treefmt-nix/e82f32aa7f06bbbd56d7b12186d555223dc399d1' (2023-11-12)
  → 'github:numtide/treefmt-nix/c6153c2a3ff4c38d231e3ae99af29b87f1df5901' (2024-01-28)
warning: Git tree '/home/runner/work/nixos/nixos' is dirty

</pre>